### PR TITLE
support non-es6 node consumers

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -6,9 +6,9 @@ function isTrue(value) {
   return !!value && value !== '0' && value !== 'false';
 }
 
-let envDisable = isTrue(process.env.DISABLE_OPENCOLLECTIVE) || isTrue(process.env.CI);
-let logLevel = process.env.npm_config_loglevel;
-let logLevelDisplay = ['silent', 'error', 'warn'].indexOf(logLevel) > -1;
+var envDisable = isTrue(process.env.DISABLE_OPENCOLLECTIVE) || isTrue(process.env.CI);
+var logLevel = process.env.npm_config_loglevel;
+var logLevelDisplay = ['silent', 'error', 'warn'].indexOf(logLevel) > -1;
 
 if (!envDisable && !logLevelDisplay) {
   console.log('Thank you for installing \u001b[35mEJS\u001b[0m: built with the \u001b[32mJake\u001b[0m JavaScript build tool (\u001b[32mhttps://jakejs.com/\u001b[0m)\n');


### PR DESCRIPTION
We found that our installs were failing because a patch version introduced let https://github.com/mde/ejs/commit/228d8e45b7ced2afd3e596c13d44aed464e57e43#r40755379

Before: 

```
46.80s$ npm install 
npm WARN package.json eco@1.1.0-rc-3 No license field.
npm WARN deprecated nodeunit@0.11.3: you are strongly encouraged to use other testing options
npm WARN deprecated coffee-script@1.12.7: CoffeeScript on NPM has moved to "coffeescript" (no hyphen)
npm WARN deprecated express@2.5.11: express 2.x series is deprecated
npm WARN deprecated connect@1.9.2: connect 1.x series is deprecated
npm WARN deprecated mkdirp@0.3.0: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
npm WARN engine tap@12.7.0: wanted: {"node":">=4"} (current: {"node":"0.12.18","npm":"2.15.11"})
> ejs@2.7.4 postinstall /home/travis/build/cesine/eco/node_modules/nodeunit/node_modules/ejs
> node ./postinstall.js
/home/travis/build/cesine/eco/node_modules/nodeunit/node_modules/ejs/postinstall.js:9
let envDisable = isTrue(process.env.DISABLE_OPENCOLLECTIVE) || isTrue(process.
^^^
SyntaxError: Unexpected strict mode reserved word
```


This creates a branch to support 2.x without impacting master (3.x) since master has a major version bump which  dropped support for older node versions https://github.com/cesine/ejs/commit/2b56f6ee8278c7d7af10050fb7c0a9606b344d2a